### PR TITLE
Fix: Correctly link the Attraction entity to the Park Device.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ A smart move would be to set automations when your ride of choice hits a low wai
 
 ## Todo / Missing Features
 
-* The device added for a theme park doesn't show any information or link to the entities. Looks like a quick fix.
 * No customisations.
 * API access is in the Integration, this should be move to PyPi so that we can add this to HA without using HACS.
 

--- a/custom_components/themeparks/__init__.py
+++ b/custom_components/themeparks/__init__.py
@@ -93,7 +93,7 @@ class ThemeParkAPI:
 
             _LOGGER.debug("Parsed API item for: %s", item[NAME])
 
-            name = item[NAME] + " (" + self._parkname + ")"
+            name = item[NAME] #+ " (" + self._parkname + ")"                      # no longer necessary after the entities are divided into groups
 
             if "queue" not in item:
                 _LOGGER.debug("No queue in item")

--- a/custom_components/themeparks/sensor.py
+++ b/custom_components/themeparks/sensor.py
@@ -57,6 +57,7 @@ class AttractionSensor(SensorEntity, CoordinatorEntity):
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_value = self.coordinator.data[self.idx][TIME]
         self._attr_unique_id = f"{coordinator.entry_id}_{coordinator.data[idx][ID]}"
+        self._attr_device_info = {"identifiers": {(DOMAIN, self.coordinator.entry_id)},}
 
         _LOGGER.debug("Adding AttractionSensor called %s", self._attr_name)
 


### PR DESCRIPTION
This change ensures that attraction entities are correctly assigned to their respective park groups.

As a follow-up, the park name prefixes have been removed from the entity names. This information is now redundant since the park context is clearly defined by the group assignment, leading to cleaner and more consistent naming.

This change solves the problem of TODO:
“The device added for a theme park doesn't show any information or link to the entities. Looks like a quick fix.”
So I removed it in the README.