### PR TITLE
Add park status sensors with schedule tracking

### DIFF
--- a/custom_components/themeparks/__init__.py
+++ b/custom_components/themeparks/__init__.py
@@ -16,8 +16,10 @@ from .const import (
     ATTR_OPENING_TIME,
     ATTR_CLOSING_TIME,
     ATTR_SCHEDULE_TYPE,
+    ATTR_ALL_SCHEDULES,
     CLOSING_TIME,
     DATE,
+    DESCRIPTION,
     DOMAIN,
     ENTITY_BASE_URL,
     ENTITY_TYPE,
@@ -187,6 +189,7 @@ class ThemeParkAPI:
                     ATTR_OPENING_TIME: park_status.get("opening_time"),
                     ATTR_CLOSING_TIME: park_status.get("closing_time"),
                     ATTR_SCHEDULE_TYPE: park_status.get("schedule_type"),
+                    ATTR_ALL_SCHEDULES: park_status.get("all_schedules", []),
                 }
                 _LOGGER.debug("Park %s status: %s", park_name, park_status["status"])
             except Exception as err:
@@ -234,7 +237,22 @@ class ThemeParkAPI:
 
         today_str = now.strftime("%Y-%m-%d")
 
-        # Find today's OPERATING schedule (main park hours)
+        # Collect ALL schedule entries for today
+        all_schedules = []
+        for entry in schedule_entries:
+            if entry.get(DATE) == today_str and OPENING_TIME in entry and CLOSING_TIME in entry:
+                schedule_dict = {
+                    "type": entry.get(SCHEDULE_TYPE, "UNKNOWN"),
+                    "name": entry.get(DESCRIPTION),  # Event name (e.g., "Early Entry", "Jollywood Nights")
+                    "opening_time": entry.get(OPENING_TIME),
+                    "closing_time": entry.get(CLOSING_TIME),
+                }
+                all_schedules.append(schedule_dict)
+
+        # Sort schedules by opening time (chronological order)
+        all_schedules.sort(key=lambda x: x["opening_time"])
+
+        # Find today's OPERATING schedule (main park hours) for primary attributes
         operating_schedule = None
         for entry in schedule_entries:
             if entry.get(DATE) == today_str and entry.get(SCHEDULE_TYPE) == TYPE_OPERATING:
@@ -249,14 +267,20 @@ class ThemeParkAPI:
                     break
 
         if not operating_schedule:
-            return {"status": "Closed"}
+            return {
+                "status": "Closed",
+                "all_schedules": all_schedules,
+            }
 
         opening_time_str = operating_schedule.get(OPENING_TIME)
         closing_time_str = operating_schedule.get(CLOSING_TIME)
         schedule_type = operating_schedule.get(SCHEDULE_TYPE, TYPE_OPERATING)
 
         if not opening_time_str or not closing_time_str:
-            return {"status": "Closed"}
+            return {
+                "status": "Closed",
+                "all_schedules": all_schedules,
+            }
 
         # Parse times (format: "2024-12-16T09:00:00-05:00")
         try:
@@ -264,7 +288,10 @@ class ThemeParkAPI:
             closing_time = datetime.fromisoformat(closing_time_str)
         except (ValueError, TypeError) as err:
             _LOGGER.error("Error parsing times: %s, %s - %s", opening_time_str, closing_time_str, err)
-            return {"status": "Unknown"}
+            return {
+                "status": "Unknown",
+                "all_schedules": all_schedules,
+            }
 
         # Determine status based on current time
         try:
@@ -284,11 +311,15 @@ class ThemeParkAPI:
                     status = "Open"
         except TypeError as err:
             _LOGGER.error("Error comparing times: %s", err)
-            return {"status": "Unknown"}
+            return {
+                "status": "Unknown",
+                "all_schedules": all_schedules,
+            }
 
         return {
             "status": status,
             "opening_time": opening_time_str,
             "closing_time": closing_time_str,
             "schedule_type": schedule_type,
+            "all_schedules": all_schedules,
         }

--- a/custom_components/themeparks/__init__.py
+++ b/custom_components/themeparks/__init__.py
@@ -1,6 +1,7 @@
 """The Theme Park Wait Times integration."""
 from __future__ import annotations
 
+from datetime import datetime
 import logging
 
 from homeassistant.config_entries import ConfigEntry
@@ -10,6 +11,13 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.httpx_client import get_async_client
 
 from .const import (
+    ATTR_PARK_NAME,
+    ATTR_PARK_STATUS,
+    ATTR_OPENING_TIME,
+    ATTR_CLOSING_TIME,
+    ATTR_SCHEDULE_TYPE,
+    CLOSING_TIME,
+    DATE,
     DOMAIN,
     ENTITY_BASE_URL,
     ENTITY_TYPE,
@@ -18,13 +26,21 @@ from .const import (
     LIVE_DATA,
     METHOD_GET,
     NAME,
+    OPENING_TIME,
+    PARKID,
     PARKNAME,
     PARKSLUG,
     QUEUE,
+    SCHEDULE,
+    SCHEDULE_DATA,
+    SCHEDULE_TYPE,
     STANDBY,
     TIME,
     TYPE_ATTRACTION,
+    TYPE_OPERATING,
     TYPE_SHOW,
+    TYPE_TICKETED_EVENT,
+    TYPE_PRIVATE_EVENT,
     WAIT_TIME,
 )
 
@@ -76,6 +92,7 @@ class ThemeParkAPI:
         self._config_entry = config_entry
         self._parkslug = config_entry.data[PARKSLUG]
         self._parkname = config_entry.data[PARKNAME]
+        self._park_cache = {}  # Cache park names by parkId
 
     async def async_initialize(self) -> None:
         """Initialize controller and connect radio."""
@@ -86,30 +103,43 @@ class ThemeParkAPI:
         """Do API lookup of the 'live' page of this park."""
         _LOGGER.debug("Running do_live_lookup in ThemeParkAPI")
 
-        items = await self.do_api_lookup()
+        items_data = await self.do_api_lookup()
+
+        # Build park name cache from PARK entities
+        for item in items_data:
+            if item[ENTITY_TYPE] == "PARK":
+                self._park_cache[item[ID]] = item[NAME]
+
+        # Filter to attractions and shows only
+        items = filter(
+            lambda item: item[ENTITY_TYPE] in [TYPE_SHOW, TYPE_ATTRACTION],
+            items_data
+        )
 
         def parse_live(item):
             """Parse live data from API."""
 
             _LOGGER.debug("Parsed API item for: %s", item[NAME])
 
-            name = item[NAME] + " (" + self._parkname + ")"
+            park_id = item.get(PARKID)
+            park_name = self._park_cache.get(park_id, self._parkname)
+            name = item[NAME]
 
-            if "queue" not in item:
-                _LOGGER.debug("No queue in item")
-                return (item[ID], {ID: item[ID], NAME: name, TIME: None})
+            wait_time = None
+            if "queue" in item and "STANDBY" in item[QUEUE]:
+                wait_time = item[QUEUE][STANDBY][WAIT_TIME]
+                _LOGGER.debug("Time found")
+            else:
+                _LOGGER.debug("No queue/STANDBY in item")
 
-            if "STANDBY" not in item[QUEUE]:
-                _LOGGER.debug("No STANDBY in item['queue']")
-                return (item[ID], {ID: item[ID], NAME: name, TIME: None})
-
-            _LOGGER.debug("Time found")
             return (
                 item[ID],
                 {
                     ID: item[ID],
                     NAME: name,
-                    TIME: item[QUEUE][STANDBY][WAIT_TIME],
+                    TIME: wait_time,
+                    PARKID: park_id,
+                    ATTR_PARK_NAME: park_name,
                 },
             )
 
@@ -129,9 +159,136 @@ class ThemeParkAPI:
 
         items_data = response.json()
 
-        def filter_item(item):
-            return (
-                item[ENTITY_TYPE] == TYPE_SHOW or item[ENTITY_TYPE] == TYPE_ATTRACTION
-            )
+        # Return all items so we can extract park information
+        return items_data[LIVE_DATA]
 
-        return filter(filter_item, items_data[LIVE_DATA])
+    async def do_schedule_lookup(self):
+        """Fetch schedule data for parks."""
+        _LOGGER.debug("Running do_schedule_lookup in ThemeParkAPI")
+
+        items_data = await self.do_api_lookup()
+        park_schedules = {}
+
+        # Get all park entities
+        parks = [item for item in items_data if item[ENTITY_TYPE] == "PARK"]
+
+        for park in parks:
+            park_id = park[ID]
+            park_name = park[NAME]
+
+            try:
+                schedule_data = await self.fetch_schedule(park_id)
+                park_status = self.parse_schedule(schedule_data)
+
+                park_schedules[park_id] = {
+                    ID: park_id,
+                    NAME: park_name,
+                    ATTR_PARK_STATUS: park_status["status"],
+                    ATTR_OPENING_TIME: park_status.get("opening_time"),
+                    ATTR_CLOSING_TIME: park_status.get("closing_time"),
+                    ATTR_SCHEDULE_TYPE: park_status.get("schedule_type"),
+                }
+                _LOGGER.debug("Park %s status: %s", park_name, park_status["status"])
+            except Exception as err:
+                _LOGGER.error("Error fetching schedule for park %s: %s", park_name, err)
+
+        return park_schedules
+
+    async def fetch_schedule(self, entity_id: str):
+        """Fetch schedule data for a specific entity."""
+        url = f"{ENTITY_BASE_URL}/{entity_id}/{SCHEDULE}"
+
+        client = get_async_client(self._hass)
+        response = await client.request(
+            METHOD_GET,
+            url,
+            timeout=30,
+            follow_redirects=True,
+        )
+
+        return response.json()
+
+    def parse_schedule(self, schedule_data):
+        """Parse schedule data to determine current park status."""
+        if SCHEDULE_DATA not in schedule_data:
+            return {"status": "Unknown"}
+
+        schedule_entries = schedule_data[SCHEDULE_DATA]
+        if not schedule_entries:
+            return {"status": "Unknown"}
+
+        # Get timezone from schedule data
+        try:
+            # Parse timezone from first entry's time
+            first_entry = schedule_entries[0]
+            if OPENING_TIME in first_entry:
+                sample_time = datetime.fromisoformat(first_entry[OPENING_TIME])
+                now = datetime.now(sample_time.tzinfo)
+            else:
+                # Fallback to UTC if no time available
+                from datetime import timezone
+                now = datetime.now(timezone.utc)
+        except (ValueError, KeyError, IndexError):
+            from datetime import timezone
+            now = datetime.now(timezone.utc)
+
+        today_str = now.strftime("%Y-%m-%d")
+
+        # Find today's OPERATING schedule (main park hours)
+        operating_schedule = None
+        for entry in schedule_entries:
+            if entry.get(DATE) == today_str and entry.get(SCHEDULE_TYPE) == TYPE_OPERATING:
+                operating_schedule = entry
+                break
+
+        # If no OPERATING schedule, look for any other type for today
+        if not operating_schedule:
+            for entry in schedule_entries:
+                if entry.get(DATE) == today_str and OPENING_TIME in entry and CLOSING_TIME in entry:
+                    operating_schedule = entry
+                    break
+
+        if not operating_schedule:
+            return {"status": "Closed"}
+
+        opening_time_str = operating_schedule.get(OPENING_TIME)
+        closing_time_str = operating_schedule.get(CLOSING_TIME)
+        schedule_type = operating_schedule.get(SCHEDULE_TYPE, TYPE_OPERATING)
+
+        if not opening_time_str or not closing_time_str:
+            return {"status": "Closed"}
+
+        # Parse times (format: "2024-12-16T09:00:00-05:00")
+        try:
+            opening_time = datetime.fromisoformat(opening_time_str)
+            closing_time = datetime.fromisoformat(closing_time_str)
+        except (ValueError, TypeError) as err:
+            _LOGGER.error("Error parsing times: %s, %s - %s", opening_time_str, closing_time_str, err)
+            return {"status": "Unknown"}
+
+        # Determine status based on current time
+        try:
+            if now < opening_time:
+                status = "Closed"
+            elif now > closing_time:
+                status = "Closed"
+            else:
+                # Park is currently open - check for special events
+                if schedule_type == TYPE_TICKETED_EVENT:
+                    status = "Special Ticketed Event"
+                elif schedule_type == TYPE_PRIVATE_EVENT:
+                    status = "Private Event"
+                elif schedule_type == TYPE_OPERATING:
+                    status = "Open"
+                else:
+                    status = "Open"
+        except TypeError as err:
+            _LOGGER.error("Error comparing times: %s", err)
+            return {"status": "Unknown"}
+
+        return {
+            "status": status,
+            "opening_time": opening_time_str,
+            "closing_time": closing_time_str,
+            "schedule_type": schedule_type,
+        }

--- a/custom_components/themeparks/const.py
+++ b/custom_components/themeparks/const.py
@@ -34,6 +34,7 @@ OPENING_TIME = "openingTime"
 CLOSING_TIME = "closingTime"
 SCHEDULE_TYPE = "type"
 DATE = "date"
+DESCRIPTION = "description"
 
 # Schedule types
 TYPE_OPERATING = "OPERATING"
@@ -47,6 +48,7 @@ ATTR_PARK_STATUS = "park_status"
 ATTR_OPENING_TIME = "opening_time"
 ATTR_CLOSING_TIME = "closing_time"
 ATTR_SCHEDULE_TYPE = "schedule_type"
+ATTR_ALL_SCHEDULES = "all_schedules"
 
 STEP_USER = "user"
 METHOD_GET = "GET"

--- a/custom_components/themeparks/const.py
+++ b/custom_components/themeparks/const.py
@@ -18,12 +18,35 @@ TYPE_ATTRACTION = "ATTRACTION"
 NAME = "name"
 TIME = "time"
 ID = "id"
+PARKID = "parkId"
+ATTR_PARK_NAME = "park_name"
 SLUG = "slug"
 DESTINATIONS = "destinations"
 QUEUE = "queue"
 STANDBY = "STANDBY"
 WAIT_TIME = "waitTime"
 LIVE = "live"
+
+# Schedule constants
+SCHEDULE = "schedule"
+SCHEDULE_DATA = "schedule"
+OPENING_TIME = "openingTime"
+CLOSING_TIME = "closingTime"
+SCHEDULE_TYPE = "type"
+DATE = "date"
+
+# Schedule types
+TYPE_OPERATING = "OPERATING"
+TYPE_TICKETED_EVENT = "TICKETED_EVENT"
+TYPE_PRIVATE_EVENT = "PRIVATE_EVENT"
+TYPE_EXTRA_HOURS = "EXTRA_HOURS"
+TYPE_INFO = "INFO"
+
+# Park status attributes
+ATTR_PARK_STATUS = "park_status"
+ATTR_OPENING_TIME = "opening_time"
+ATTR_CLOSING_TIME = "closing_time"
+ATTR_SCHEDULE_TYPE = "schedule_type"
 
 STEP_USER = "user"
 METHOD_GET = "GET"

--- a/custom_components/themeparks/sensor.py
+++ b/custom_components/themeparks/sensor.py
@@ -18,7 +18,18 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import DOMAIN, NAME, TIME, ID
+from .const import (
+    ATTR_PARK_NAME,
+    ATTR_PARK_STATUS,
+    ATTR_OPENING_TIME,
+    ATTR_CLOSING_TIME,
+    ATTR_SCHEDULE_TYPE,
+    DOMAIN,
+    NAME,
+    PARKID,
+    TIME,
+    ID,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,17 +42,35 @@ async def async_setup_entry(
     """Set up the sensor platform."""
 
     my_api = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator = ThemeParksCoordinator(hass, my_api, config_entry.entry_id)
 
-    await coordinator.async_config_entry_first_refresh()
+    # Set up wait time coordinator
+    wait_time_coordinator = ThemeParksCoordinator(hass, my_api, config_entry.entry_id)
+    await wait_time_coordinator.async_config_entry_first_refresh()
+
+    # Set up park schedule coordinator
+    park_schedule_coordinator = ParkScheduleCoordinator(hass, my_api, config_entry.entry_id)
+    await park_schedule_coordinator.async_config_entry_first_refresh()
 
     _LOGGER.info("Config entry first refresh completed, adding entities")
-    entities = [AttractionSensor(coordinator, idx) for idx in coordinator.data.keys()]
+
+    # Create attraction sensors
+    attraction_entities = [
+        AttractionSensor(wait_time_coordinator, idx)
+        for idx in wait_time_coordinator.data.keys()
+    ]
+
+    # Create park status sensors
+    park_entities = [
+        ParkSensor(park_schedule_coordinator, idx)
+        for idx in park_schedule_coordinator.data.keys()
+    ]
+
+    all_entities = attraction_entities + park_entities
 
     _LOGGER.info(
-        "Entities to add (count: %s): %s", str(entities.__len__), str(entities)
+        "Entities to add (count: %s): %s", str(all_entities.__len__), str(all_entities)
     )
-    async_add_entities(entities)
+    async_add_entities(all_entities)
 
 
 class AttractionSensor(SensorEntity, CoordinatorEntity):
@@ -51,14 +80,43 @@ class AttractionSensor(SensorEntity, CoordinatorEntity):
         """Pass coordinator to CoordinatorEntity."""
         super().__init__(coordinator)
         self.idx = idx
-        self._attr_name = coordinator.data[idx][NAME]
+        attraction_data = coordinator.data[idx]
+
+        self._attr_name = attraction_data[NAME]
         self._attr_native_unit_of_measurement = UnitOfTime.MINUTES
         self._attr_device_class = SensorDeviceClass.DURATION
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_native_value = self.coordinator.data[self.idx][TIME]
-        self._attr_unique_id = f"{coordinator.entry_id}_{coordinator.data[idx][ID]}"
+        self._attr_native_value = attraction_data[TIME]
+        self._attr_unique_id = f"{coordinator.entry_id}_{attraction_data[ID]}"
 
-        _LOGGER.debug("Adding AttractionSensor called %s", self._attr_name)
+        # Use parkId for device association
+        park_id = attraction_data.get(PARKID)
+        self._park_name = attraction_data.get(ATTR_PARK_NAME, "Unknown Park")
+
+        if park_id:
+            self._attr_device_info = {
+                "identifiers": {(DOMAIN, park_id)},
+                "name": self._park_name,
+                "manufacturer": "Theme Parks",
+                "model": "Theme Park",
+            }
+        else:
+            # Fallback to entry_id if parkId not available
+            self._attr_device_info = {
+                "identifiers": {(DOMAIN, self.coordinator.entry_id)},
+                "name": self.coordinator.api._parkname,
+                "manufacturer": "Theme Parks",
+                "model": "Wait Times",
+            }
+
+        _LOGGER.debug("Adding AttractionSensor called %s to park %s", self._attr_name, self._park_name)
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            ATTR_PARK_NAME: self._park_name,
+        }
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -91,3 +149,73 @@ class ThemeParksCoordinator(DataUpdateCoordinator):
         """Fetch data from API endpoint."""
         _LOGGER.debug("Calling do_live_lookup in ThemeParksCoordinator")
         return await self.api.do_live_lookup()
+
+
+class ParkSensor(SensorEntity, CoordinatorEntity):
+    """Sensor for park status."""
+
+    def __init__(self, coordinator, idx):
+        """Pass coordinator to CoordinatorEntity."""
+        super().__init__(coordinator)
+        self.idx = idx
+        park_data = coordinator.data[idx]
+
+        self._attr_name = f"{park_data[NAME]} Status"
+        self._attr_native_value = park_data[ATTR_PARK_STATUS]
+        self._attr_unique_id = f"{coordinator.entry_id}_{park_data[ID]}_status"
+
+        # Device info for park
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, park_data[ID])},
+            "name": park_data[NAME],
+            "manufacturer": "Theme Parks",
+            "model": "Theme Park",
+        }
+
+        self._park_id = park_data[ID]
+        self._park_name = park_data[NAME]
+
+        _LOGGER.debug("Adding ParkSensor for %s", self._park_name)
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        park_data = self.coordinator.data.get(self.idx, {})
+        return {
+            ATTR_OPENING_TIME: park_data.get(ATTR_OPENING_TIME),
+            ATTR_CLOSING_TIME: park_data.get(ATTR_CLOSING_TIME),
+            ATTR_SCHEDULE_TYPE: park_data.get(ATTR_SCHEDULE_TYPE),
+        }
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        park_data = self.coordinator.data.get(self.idx, {})
+        new_status = park_data.get(ATTR_PARK_STATUS)
+        _LOGGER.debug(
+            "Setting updated status from coordinator for %s to %s",
+            str(self._attr_name),
+            str(new_status),
+        )
+        self._attr_native_value = new_status
+        self.async_write_ha_state()
+
+
+class ParkScheduleCoordinator(DataUpdateCoordinator):
+    """Park schedule coordinator."""
+
+    def __init__(self, hass, api, entry_id):
+        """Initialize park schedule coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="Theme Park Schedule Sensor",
+            update_interval=timedelta(minutes=15),
+        )
+        self.api = api
+        self.entry_id = entry_id
+
+    async def _async_update_data(self):
+        """Fetch data from API endpoint."""
+        _LOGGER.debug("Calling do_schedule_lookup in ParkScheduleCoordinator")
+        return await self.api.do_schedule_lookup()

--- a/custom_components/themeparks/sensor.py
+++ b/custom_components/themeparks/sensor.py
@@ -24,6 +24,7 @@ from .const import (
     ATTR_OPENING_TIME,
     ATTR_CLOSING_TIME,
     ATTR_SCHEDULE_TYPE,
+    ATTR_ALL_SCHEDULES,
     DOMAIN,
     NAME,
     PARKID,
@@ -185,6 +186,7 @@ class ParkSensor(SensorEntity, CoordinatorEntity):
             ATTR_OPENING_TIME: park_data.get(ATTR_OPENING_TIME),
             ATTR_CLOSING_TIME: park_data.get(ATTR_CLOSING_TIME),
             ATTR_SCHEDULE_TYPE: park_data.get(ATTR_SCHEDULE_TYPE),
+            ATTR_ALL_SCHEDULES: park_data.get(ATTR_ALL_SCHEDULES, []),
         }
 
     @callback


### PR DESCRIPTION
This adds new sensors that display the current operational status of parks based on their schedules from the Theme Parks API.

Features:
- Creates a status sensor for each park showing: Open, Closed, Special Ticketed Event, or Private Event
- Displays opening and closing times as attributes
- Shows schedule type (OPERATING, TICKETED_EVENT, PRIVATE_EVENT, etc.)
- Uses timezone-aware datetime for accurate status calculations

Changes:
- const.py: Added schedule-related constants and attribute names
- __init__.py: Added schedule fetching and parsing methods to ThemeParkAPI
- sensor.py: Added ParkSensor entity and ParkScheduleCoordinator

The status sensors are useful for dashboard displays to show park availability and differentiate between normal hours and special events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)